### PR TITLE
bug fix in FF Mapping cells

### DIFF
--- a/platform/sky130_fd_sc_hd/sky130_fd_sc_hd_ff_map.v
+++ b/platform/sky130_fd_sc_hd/sky130_fd_sc_hd_ff_map.v
@@ -15,6 +15,33 @@
 */
 
 
+/***************************************************
+Reference: yosys/techlibs/common/simlib.v
+
+module \$adffe (CLK, ARST, EN, D, Q);
+
+parameter WIDTH = 0;
+parameter CLK_POLARITY = 1'b1;
+parameter EN_POLARITY = 1'b1;
+parameter ARST_POLARITY = 1'b1;
+parameter ARST_VALUE = 0;
+
+input CLK, ARST, EN;
+input [WIDTH-1:0] D;
+output reg [WIDTH-1:0] Q;
+wire pos_clk = CLK == CLK_POLARITY;
+wire pos_arst = ARST == ARST_POLARITY;
+
+always @(posedge pos_clk, posedge pos_arst) begin
+	if (pos_arst)
+		Q <= ARST_VALUE;
+	else if (EN == EN_POLARITY)
+		Q <= D;
+end
+
+endmodule
+
+******************************************************/
 
 module \$adffe (ARST, CLK, D, EN, Q);
     parameter ARST_POLARITY =1'b1;
@@ -28,16 +55,47 @@ module \$adffe (ARST, CLK, D, EN, Q);
     output [WIDTH -1 :0] Q;
 
     wire GCLK;
+    wire cg_enb;
+    wire cg_clk;
+    wire cg_gclk;
 
+    // Check the Polarity of Clock Gate Enable
+    generate
+        if(EN_POLARITY == 0) begin
+          assign cg_enb = ~EN;
+        end else begin
+          assign cg_enb = EN;
+        end
+    endgenerate
+    
+    // Check the Polarity of Clock 
+    generate
+        if(CLK_POLARITY == 0) begin
+          assign cg_clk = ~CLK;
+        end else begin
+          assign cg_clk = CLK;
+        end
+    endgenerate
+
+    // Check the Width the Data
     generate
         if (WIDTH < 5) begin
-                sky130_fd_sc_hd__dlclkp_1  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_1  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
                 end
             else if (WIDTH < 17) begin
-                sky130_fd_sc_hd__dlclkp_2  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_2  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
                 end
             else begin
-                sky130_fd_sc_hd__dlclkp_4  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_4  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
+        end
+    endgenerate
+    
+    // Check the Polarity of Clock 
+    generate
+        if(CLK_POLARITY == 0) begin
+          assign cg_gclk = ~GCLK;
+        end else begin
+          assign cg_gclk = GCLK;
         end
     endgenerate
 
@@ -48,7 +106,7 @@ module \$adffe (ARST, CLK, D, EN, Q);
             .ARST_POLARITY (ARST_POLARITY)
             ) 
             flipflop(  
-            .CLK(GCLK), 
+            .CLK(cg_gclk), 
             .ARST(ARST),
             .D(D), 
             .Q(Q)
@@ -57,6 +115,27 @@ endmodule
 
 //////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////
+
+/**************************************************************
+Reference: yosys/techlibs/common/simlib.v
+
+module \$dffe (CLK, EN, D, Q);
+
+parameter WIDTH = 0;
+parameter CLK_POLARITY = 1'b1;
+parameter EN_POLARITY = 1'b1;
+
+input CLK, EN;
+input [WIDTH-1:0] D;
+output reg [WIDTH-1:0] Q;
+wire pos_clk = CLK == CLK_POLARITY;
+
+always @(posedge pos_clk) begin
+	if (EN == EN_POLARITY) Q <= D;
+end
+
+endmodule
+******************************************************************/
 
 module \$dffe ( CLK, D, EN, Q);
     parameter CLK_POLARITY =1'b1;
@@ -68,16 +147,47 @@ module \$dffe ( CLK, D, EN, Q);
     output [WIDTH -1:0] Q;
 
     wire GCLK;
+    wire cg_enb;
+    wire cg_clk;
+    wire cg_gclk;
 
+    // Check the Polarity of Clock Gate Enable
+    generate
+        if(EN_POLARITY == 0) begin
+          assign cg_enb = ~EN;
+        end else begin
+          assign cg_enb = EN;
+        end
+    endgenerate
+    
+    // Check the Polarity of Clock 
+    generate
+        if(CLK_POLARITY == 0) begin
+          assign cg_clk = ~CLK;
+        end else begin
+          assign cg_clk = CLK;
+        end
+    endgenerate
+
+    // Check the Width the Data
     generate
         if (WIDTH < 5) begin
-                sky130_fd_sc_hd__dlclkp_1  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_1  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
                 end
             else if (WIDTH < 17) begin
-                sky130_fd_sc_hd__dlclkp_2  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_2  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
                 end
             else begin
-                sky130_fd_sc_hd__dlclkp_4  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_4  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
+        end
+    endgenerate
+    
+    // Check the Polarity of Clock 
+    generate
+        if(CLK_POLARITY == 0) begin
+          assign cg_gclk = ~GCLK;
+        end else begin
+          assign cg_gclk = GCLK;
         end
     endgenerate
 
@@ -86,7 +196,7 @@ module \$dffe ( CLK, D, EN, Q);
             .CLK_POLARITY(CLK_POLARITY),
             ) 
             flipflop(  
-            .CLK(GCLK), 
+            .CLK(cg_gclk), 
             .D(D), 
             .Q(Q)
             );
@@ -95,6 +205,41 @@ endmodule
 //////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////
 
+/**********************************************************
+Reference: yosys/techlibs/common/simlib.v
+
+module \$dffsre (CLK, SET, CLR, EN, D, Q);
+
+parameter WIDTH = 0;
+parameter CLK_POLARITY = 1'b1;
+parameter SET_POLARITY = 1'b1;
+parameter CLR_POLARITY = 1'b1;
+parameter EN_POLARITY = 1'b1;
+
+input CLK, EN;
+input [WIDTH-1:0] SET, CLR, D;
+output reg [WIDTH-1:0] Q;
+
+wire pos_clk = CLK == CLK_POLARITY;
+wire [WIDTH-1:0] pos_set = SET_POLARITY ? SET : ~SET;
+wire [WIDTH-1:0] pos_clr = CLR_POLARITY ? CLR : ~CLR;
+
+genvar i;
+generate
+	for (i = 0; i < WIDTH; i = i+1) begin:bitslices
+		always @(posedge pos_set[i], posedge pos_clr[i], posedge pos_clk)
+			if (pos_clr[i])
+				Q[i] <= 0;
+			else if (pos_set[i])
+				Q[i] <= 1;
+			else if (EN == EN_POLARITY)
+				Q[i] <= D[i];
+	end
+endgenerate
+
+endmodule
+
+***********************************************************/
 module \$dffsre ( CLK, EN, CLR, SET, D, Q);
     parameter CLK_POLARITY =1'b1;
     parameter EN_POLARITY =1'b1;
@@ -107,16 +252,47 @@ module \$dffsre ( CLK, EN, CLR, SET, D, Q);
     output [WIDTH -1:0] Q;
 
     wire GCLK;
+    wire cg_enb;
+    wire cg_clk;
+    wire cg_gclk;
 
+    // Check the Polarity of Clock Gate Enable
+    generate
+        if(EN_POLARITY == 0) begin
+          assign cg_enb = ~EN;
+        end else begin
+          assign cg_enb = EN;
+        end
+    endgenerate
+    
+    // Check the Polarity of Clock 
+    generate
+        if(CLK_POLARITY == 0) begin
+          assign cg_clk = ~CLK;
+        end else begin
+          assign cg_clk = CLK;
+        end
+    endgenerate
+
+    // Check the Width the Data
     generate
         if (WIDTH < 5) begin
-                sky130_fd_sc_hd__dlclkp_1  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_1  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
                 end
             else if (WIDTH < 17) begin
-                sky130_fd_sc_hd__dlclkp_2  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_2  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
                 end
             else begin
-                sky130_fd_sc_hd__dlclkp_4  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_4  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
+        end
+    endgenerate
+    
+    // Check the Polarity of Clock 
+    generate
+        if(CLK_POLARITY == 0) begin
+          assign cg_gclk = ~GCLK;
+        end else begin
+          assign cg_gclk = GCLK;
         end
     endgenerate
 
@@ -127,7 +303,7 @@ module \$dffsre ( CLK, EN, CLR, SET, D, Q);
             .SET_POLARITY(SET_POLARITY)
             ) 
             flipflop(  
-            .CLK(GCLK), 
+            .CLK(cg_gclk), 
             .CLR(CLR),
             .SET(SET),
             .D(D), 
@@ -137,6 +313,33 @@ endmodule
 
 //////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////
+/*****************************
+Reference: yosys/techlibs/common/simlib.v
+
+module \$aldffe (CLK, ALOAD, AD, EN, D, Q);
+
+parameter WIDTH = 0;
+parameter CLK_POLARITY = 1'b1;
+parameter EN_POLARITY = 1'b1;
+parameter ALOAD_POLARITY = 1'b1;
+
+input CLK, ALOAD, EN;
+input [WIDTH-1:0] D;
+input [WIDTH-1:0] AD;
+output reg [WIDTH-1:0] Q;
+wire pos_clk = CLK == CLK_POLARITY;
+wire pos_aload = ALOAD == ALOAD_POLARITY;
+
+always @(posedge pos_clk, posedge pos_aload) begin
+	if (pos_aload)
+		Q <= AD;
+	else if (EN == EN_POLARITY)
+		Q <= D;
+end
+
+endmodule
+
+*************************************************/
 
 module \$aldffe ( CLK, EN, ALOAD, AD, D, Q);
     parameter CLK_POLARITY =1'b1;
@@ -150,16 +353,47 @@ module \$aldffe ( CLK, EN, ALOAD, AD, D, Q);
     output [WIDTH -1:0] Q;
 
     wire GCLK;
+    wire cg_enb;
+    wire cg_clk;
+    wire cg_gclk;
 
+    // Check the Polarity of Clock Gate Enable
+    generate
+        if(EN_POLARITY == 0) begin
+          assign cg_enb = ~EN;
+        end else begin
+          assign cg_enb = EN;
+        end
+    endgenerate
+    
+    // Check the Polarity of Clock 
+    generate
+        if(CLK_POLARITY == 0) begin
+          assign cg_clk = ~CLK;
+        end else begin
+          assign cg_clk = CLK;
+        end
+    endgenerate
+
+    // Check the Width the Data
     generate
         if (WIDTH < 5) begin
-                sky130_fd_sc_hd__dlclkp_1  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_1  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
                 end
             else if (WIDTH < 17) begin
-                sky130_fd_sc_hd__dlclkp_2  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_2  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
                 end
             else begin
-                sky130_fd_sc_hd__dlclkp_4  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_4  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
+        end
+    endgenerate
+    
+    // Check the Polarity of Clock 
+    generate
+        if(CLK_POLARITY == 0) begin
+          assign cg_gclk = ~GCLK;
+        end else begin
+          assign cg_gclk = GCLK;
         end
     endgenerate
 
@@ -169,7 +403,7 @@ module \$aldffe ( CLK, EN, ALOAD, AD, D, Q);
             .ALOAD_POLARITY(ALOAD_POLARITY), 
             ) 
             flipflop(  
-            .CLK(GCLK), 
+            .CLK(cg_gclk), 
             .D(D),
             .AD(AD),
             .Q(Q)
@@ -178,49 +412,149 @@ endmodule
 
 //////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////
+/*************************************************************************************
 
-//module \$sdffe ( CLK, EN, SRST, D, Q);
-//    parameter CLK_POLARITY =1'b1;
-//    parameter EN_POLARITY =1'b1;
-//    parameter SRST_POLARITY =1'b1;
-//    parameter SRST_VALUE =1'b1;
-//    parameter WIDTH =1;
+Reference: yosys/techlibs/common/simlib.v
+
+module \$sdffe (CLK, SRST, EN, D, Q);
+
+parameter WIDTH = 0;
+parameter CLK_POLARITY = 1'b1;
+parameter EN_POLARITY = 1'b1;
+parameter SRST_POLARITY = 1'b1;
+parameter SRST_VALUE = 0;
+
+input CLK, SRST, EN;
+input [WIDTH-1:0] D;
+output reg [WIDTH-1:0] Q;
+wire pos_clk = CLK == CLK_POLARITY;
+wire pos_srst = SRST == SRST_POLARITY;
+
+always @(posedge pos_clk) begin
+	if (pos_srst)
+		Q <= SRST_VALUE;
+	else if (EN == EN_POLARITY)
+		Q <= D;
+end
+
+endmodule
+
+Note: This is synchronous FF and EN valid after reset assertion. To use the clock gate we need to propgate clock during reset phase
+
+*******************************/
+
+module \$sdffe ( CLK, EN, SRST, D, Q);
+    parameter CLK_POLARITY =1'b1;
+    parameter EN_POLARITY =1'b1;
+    parameter SRST_POLARITY =1'b1;
+    parameter SRST_VALUE =1'b1;
+    parameter WIDTH =1;
 
 
-//    input  CLK, EN, SRST;
-//    input [WIDTH -1:0] D; 
-//    output [WIDTH -1:0] Q;
+    input  CLK, EN, SRST;
+    input [WIDTH -1:0] D; 
+    output [WIDTH -1:0] Q;
 
-//    wire GCLK;
+    wire GCLK;
+    wire cg_enb;
+    wire cg_clk;
+    wire cg_gclk;
+    wire cg_rstenb;
 
-//    generate
-//        if (WIDTH < 5) begin
-//                sky130_fd_sc_hd__dlclkp_1  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
-//                end
-//            else if (WIDTH < 17) begin
-//                sky130_fd_sc_hd__dlclkp_2  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
-//                end
-//            else begin
-//                sky130_fd_sc_hd__dlclkp_4  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
-//        end
-//    endgenerate
+    // Check the Polarity of Clock Gate Enable
+    generate
+        if(SRST_POLARITY == 0) begin
+          assign cg_rstenb = ~SRST;
+        end else begin
+          assign cg_rstenb = SRST;
+        end
+    endgenerate
 
-//    $sdff  #( 
-//            .WIDTH(WIDTH), 
-//            .CLK_POLARITY(CLK_POLARITY),
-//            .SRST_POLARITY(SRST_POLARITY), 
-//            .SRST_VALUE(SRST_VALUE)
-//            ) 
-//            flipflop(  
-//            .CLK(GCLK), 
-//            .SRST(SRST),
-//            .D(D), 
-//            .Q(Q)
-//            );
-//endmodule
+    // Check the Polarity of Clock Gate Enable
+    // We need to enable clock during reset assertion
+    generate
+        if(EN_POLARITY == 0) begin
+          assign cg_enb = (~EN) | cg_rstenb;
+        end else begin
+          assign cg_enb = EN | cg_rstenb;
+        end
+    endgenerate
+    
+    // Check the Polarity of Clock 
+    generate
+        if(CLK_POLARITY == 0) begin
+          assign cg_clk = ~CLK;
+        end else begin
+          assign cg_clk = CLK;
+        end
+    endgenerate
+
+    // Check the Width the Data
+    generate
+        if (WIDTH < 5) begin
+                sky130_fd_sc_hd__dlclkp_1  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
+                end
+            else if (WIDTH < 17) begin
+                sky130_fd_sc_hd__dlclkp_2  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
+                end
+            else begin
+                sky130_fd_sc_hd__dlclkp_4  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
+        end
+    endgenerate
+    
+    // Check the Polarity of Clock 
+    generate
+        if(CLK_POLARITY == 0) begin
+          assign cg_gclk = ~GCLK;
+        end else begin
+          assign cg_gclk = GCLK;
+        end
+    endgenerate
+
+    $sdff  #( 
+            .WIDTH(WIDTH), 
+            .CLK_POLARITY(CLK_POLARITY),
+            .SRST_POLARITY(SRST_POLARITY), 
+            .SRST_VALUE(SRST_VALUE)
+            ) 
+            flipflop(  
+            .CLK(cg_gclk), 
+            .SRST(SRST),
+            .D(D), 
+            .Q(Q)
+            );
+endmodule
 
 //////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////
+
+/********************************************************************
+
+module \$sdffce (CLK, SRST, EN, D, Q);
+
+parameter WIDTH = 0;
+parameter CLK_POLARITY = 1'b1;
+parameter EN_POLARITY = 1'b1;
+parameter SRST_POLARITY = 1'b1;
+parameter SRST_VALUE = 0;
+
+input CLK, SRST, EN;
+input [WIDTH-1:0] D;
+output reg [WIDTH-1:0] Q;
+wire pos_clk = CLK == CLK_POLARITY;
+wire pos_srst = SRST == SRST_POLARITY;
+
+always @(posedge pos_clk) begin
+	if (EN == EN_POLARITY) begin
+		if (pos_srst)
+			Q <= SRST_VALUE;
+		else
+			Q <= D;
+	end
+end
+
+endmodule
+***********************************************************************/
 
 module \$sdffce ( CLK, EN, SRST, D, Q);
     parameter CLK_POLARITY =1'b1;
@@ -233,17 +567,51 @@ module \$sdffce ( CLK, EN, SRST, D, Q);
     input [WIDTH -1:0] D; 
     output [WIDTH -1:0] Q;
 
-    wire GCLK;
 
+    wire GCLK;
+    wire cg_enb;
+    wire cg_clk;
+    wire cg_gclk;
+
+
+    // Check the Polarity of Clock Gate Enable
+    // We need to enable clock during reset assertion
+    generate
+        if(EN_POLARITY == 0) begin
+          assign cg_enb = ~EN ;
+        end else begin
+          assign cg_enb = EN ;
+        end
+    endgenerate
+    
+    // Check the Polarity of Clock 
+    generate
+        if(CLK_POLARITY == 0) begin
+          assign cg_clk = ~CLK;
+        end else begin
+          assign cg_clk = CLK;
+        end
+    endgenerate
+
+    // Check the Width the Data
     generate
         if (WIDTH < 5) begin
-                sky130_fd_sc_hd__dlclkp_1  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_1  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
                 end
             else if (WIDTH < 17) begin
-                sky130_fd_sc_hd__dlclkp_2  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_2  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
                 end
             else begin
-                sky130_fd_sc_hd__dlclkp_4  clk_gate ( .GCLK(GCLK), .CLK(CLK), .GATE(EN) );
+                sky130_fd_sc_hd__dlclkp_4  clk_gate ( .GCLK(GCLK), .CLK(cg_clk), .GATE(cg_enb) );
+        end
+    endgenerate
+    
+    // Check the Polarity of Clock 
+    generate
+        if(CLK_POLARITY == 0) begin
+          assign cg_gclk = ~GCLK;
+        end else begin
+          assign cg_gclk = GCLK;
         end
     endgenerate
 
@@ -254,7 +622,7 @@ module \$sdffce ( CLK, EN, SRST, D, Q);
             .SRST_VALUE(SRST_VALUE)
             ) 
             flipflop(  
-            .CLK(GCLK), 
+            .CLK(cg_gclk), 
             .SRST(SRST),
             .D(D), 
             .Q(Q)

--- a/validation/README.md
+++ b/validation/README.md
@@ -1,0 +1,3 @@
+yosys-config --build cg_plugin.so clock_gating_plugin.cc
+python synth_test.py
+python validate.py


### PR DESCRIPTION
# Signed by: Youssef Kandil
# Contributer: @dineshannayya 
# Context: 
The Clock gating of $SDFFE cells was crashing validation due to the forced positive signaling of the clock and enable signals. 

# Changes: 
Checking the polarity of the "clock" and the "enable" signals and adjusting their sign respectively. This PR closes #2  



@dineshannayya 
@shalan 